### PR TITLE
Conditional request workflow

### DIFF
--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -123,6 +123,10 @@ class Compiler {
     // return ops.expand(payload => Rx.of(payload).pipe(commandsOperation))
   }
 
+  private compileFilterOperation(operation: I.FilterOperation): Stream.Operation {
+    const evaluator = new BooleanExpressionEvaluator(operation.expression)
+    return ops.filter((payload) => evaluator.eval(payload))
+  }
   private compileUntilOperation(operation: I.UntilOperation): Stream.Operation {
     const evaluator = new BooleanExpressionEvaluator(operation.expression)
     return ops.takeWhile((payload) => !evaluator.eval(payload))
@@ -142,6 +146,8 @@ class Compiler {
           return this.compileMergeOperation(operation)
         case 'reduce':
           return this.compileReduceOperation(operation)
+        case 'filter':
+          return this.compileFilterOperation(operation)
         case 'until':
           return this.compileUntilOperation(operation)
         default:

--- a/src/dsl-parser/grammar.ne
+++ b/src/dsl-parser/grammar.ne
@@ -175,7 +175,7 @@ PostProgram               -> (Comment | nl_):*                                  
 
 Program                   -> Flow                                                           {% extractProgramFlow %}
                            | Program "\n":? (".map" | ".reduce" | ".loop" | ".catch") Flow  {% extractProgramDotFlow %}
-                           | Program "\n":? (".until") ExpressionBlock                      {% extractProgramExpressionFlow %}
+                           | Program "\n":? (".until" | ".filter") ExpressionBlock         {% extractProgramExpressionFlow %}
                            | Program "\n":? ".merge(" ProgramList ")"                      {% extractProgramMerge %}
 
 ProgramList               -> ws Program ws                                            {% extractProgramList %}

--- a/src/dsl-parser/post-process.ts
+++ b/src/dsl-parser/post-process.ts
@@ -70,6 +70,9 @@ function postProcessProgram(program: i.Program): any {
       case 'until':
         operation.expression = postProcessExpression(operation.expression)
         return operation
+      case 'filter':
+        operation.expression = postProcessExpression(operation.expression)
+        return operation
       case 'merge':
         operation.programs = postProcessPrograms(operation.programs)
         return operation

--- a/src/runtime/commands/parse-command.ts
+++ b/src/runtime/commands/parse-command.ts
@@ -17,7 +17,7 @@ class CheerioParser implements ParserEngine {
   public load(html: string) {
     this.$ = cheerio.load(html, this.cheerioFlags)
   }
-  public forEach: ParserEngine['forEach'] = cb => {
+  public forEach: ParserEngine['forEach'] = (cb) => {
     const { $ } = this
     const { SELECTOR, ATTR, MAX } = this.command.params
     // we could also set up an generator here, depending on what is better for jsonata parser
@@ -63,7 +63,7 @@ class DelimiterParser implements ParserEngine {
     this.text = text
   }
 
-  public forEach: ParserEngine['forEach'] = cb => {
+  public forEach: ParserEngine['forEach'] = (cb) => {
     this.text.split(this.regex).forEach((value, i) => cb(value, i))
   }
 }
@@ -73,7 +73,7 @@ class ParseCommand extends BaseCommand<I.ParseCommand, typeof ParseCommand.DEFAU
     FORMAT: 'html' as NonNullable<I.ParseCommand['params']['FORMAT']>,
     ATTR: undefined,
     MAX: undefined,
-    TRIM: false
+    TRIM: false,
   }
   private parserEngine: ParserEngine
 

--- a/src/runtime/commands/parse-command.ts
+++ b/src/runtime/commands/parse-command.ts
@@ -17,7 +17,7 @@ class CheerioParser implements ParserEngine {
   public load(html: string) {
     this.$ = cheerio.load(html, this.cheerioFlags)
   }
-  public forEach: ParserEngine['forEach'] = (cb) => {
+  public forEach: ParserEngine['forEach'] = cb => {
     const { $ } = this
     const { SELECTOR, ATTR, MAX } = this.command.params
     // we could also set up an generator here, depending on what is better for jsonata parser
@@ -51,11 +51,29 @@ class JsonataParser implements ParserEngine {
   }
 }
 
+class DelimiterParser implements ParserEngine {
+  private regex: RegExp
+  private text: string
+
+  public constructor(private command: I.ParseCommand) {
+    this.regex = new RegExp(command.params.SELECTOR)
+  }
+
+  public load(text: string) {
+    this.text = text
+  }
+
+  public forEach: ParserEngine['forEach'] = cb => {
+    this.text.split(this.regex).forEach((value, i) => cb(value, i))
+  }
+}
+
 class ParseCommand extends BaseCommand<I.ParseCommand, typeof ParseCommand.DEFAULT_PARAMS> {
   public static DEFAULT_PARAMS = {
     FORMAT: 'html' as NonNullable<I.ParseCommand['params']['FORMAT']>,
     ATTR: undefined,
     MAX: undefined,
+    TRIM: false
   }
   private parserEngine: ParserEngine
 
@@ -71,6 +89,9 @@ class ParseCommand extends BaseCommand<I.ParseCommand, typeof ParseCommand.DEFAU
       case 'json':
         this.parserEngine = new JsonataParser(this.command)
         break
+      case 'delimiter':
+        this.parserEngine = new DelimiterParser(this.command)
+        break
       default:
         throw new Error(`Unsupported format type '${this.params.FORMAT}'`)
     }
@@ -79,11 +100,13 @@ class ParseCommand extends BaseCommand<I.ParseCommand, typeof ParseCommand.DEFAU
   public stream(payload: Stream.Payload) {
     const parsedResult: Stream.Payload[] = []
 
-    this.parserEngine.load(payload.value)
+    const preProcessedValue = this.params.TRIM ? payload.value.trim() : payload.value
+    this.parserEngine.load(preProcessedValue)
 
     this.tools.store.transaction(() => {
       this.parserEngine.forEach((value, i) => {
-        const newPayload = this.saveValue(payload, i, value)
+        const processedValue = this.params.TRIM ? value.trim() : value
+        const newPayload = this.saveValue(payload, i, processedValue)
         parsedResult.push(newPayload)
       })
     })()

--- a/src/runtime/tools/store-tool/queries/select-ordered-labeled-values.ts
+++ b/src/runtime/tools/store-tool/queries/select-ordered-labeled-values.ts
@@ -202,6 +202,7 @@ class QueryCompiler {
         }
         // read only operators
         case 'until':
+        case 'filter':
           return this.collectInfo(program, operationIndex + 1, 0, distanceFromTop, previousCommand)
         default:
           throw new errors.InternalError(`unknown operation '${operation.operator}'`)

--- a/src/types/instructions.ts
+++ b/src/types/instructions.ts
@@ -67,8 +67,9 @@ type FetchCommand = RawCommand<'FETCH', FetchParams>
 interface ParseParams {
   LABEL?: string
   SELECTOR: string
-  FORMAT?: 'html' | 'xml' | 'json'
+  FORMAT?: 'html' | 'xml' | 'json' | 'delimiter'
   ATTR?: string
+  TRIM?: boolean // trim any remaining whitespace
   MAX?: number
 }
 type ParseCommand = RawCommand<'PARSE', ParseParams>

--- a/src/types/instructions.ts
+++ b/src/types/instructions.ts
@@ -169,5 +169,5 @@ export {
   FetchCommand,
   ParseCommand,
   TextReplaceCommand,
-  SetVarCommand
+  SetVarCommand,
 }

--- a/src/types/instructions.ts
+++ b/src/types/instructions.ts
@@ -98,6 +98,10 @@ interface UntilOperation {
   operator: 'until'
   expression: Expression
 }
+interface FilterOperation {
+  operator: 'filter'
+  expression: Expression
+}
 interface MapOperation {
   operator: 'map'
   commands: Command[]
@@ -127,6 +131,7 @@ interface MergeOperation {
 type Operation =
   | InitOperation
   | UntilOperation
+  | FilterOperation
   | MapOperation
   | ReduceOperation
   | LoopOperation
@@ -150,6 +155,7 @@ export {
   Template,
   InitOperation,
   UntilOperation,
+  FilterOperation,
   MapOperation,
   ReduceOperation,
   LoopOperation,
@@ -163,5 +169,5 @@ export {
   FetchCommand,
   ParseCommand,
   TextReplaceCommand,
-  SetVarCommand,
+  SetVarCommand
 }

--- a/test/functional/parsing/fixtures/multiline-text-body.html
+++ b/test/functional/parsing/fixtures/multiline-text-body.html
@@ -1,0 +1,15 @@
+<html>
+  <body>
+    <pre>
+      acl.tcz
+      advcomp.tcz
+      alsa-plugins-dev.tcz
+      alsa-plugins.tcz
+      alsa.tcz
+      alsa-utils.tcz
+      attr.tcz
+      autoconf2.13.tcz
+      autoconf.tcz
+    </pre>
+  </body>
+</html>

--- a/test/functional/parsing/fixtures/success.json
+++ b/test/functional/parsing/fixtures/success.json
@@ -1,0 +1,3 @@
+{
+  "success": true
+}

--- a/test/functional/parsing/functional.test.ts
+++ b/test/functional/parsing/functional.test.ts
@@ -66,7 +66,8 @@ describe(__filename, () => {
       it('should be able to be fed from another parser', async () => {
         const scraper = new ScraperProgram(
           instructions.parseMultilineTextAsSingleLines,
-          testEnv.outputFolder
+          testEnv.outputFolder,
+          { inputs: { packageName: 'autoconf2.13.tcz' } }
         )
         await scraper.start().toPromise()
 
@@ -84,6 +85,13 @@ describe(__filename, () => {
               { value: 'autoconf2.13.tcz' },
               { value: 'autoconf.tcz' }
             ]
+          }
+        ])
+
+        const apiResult = scraper.query(['api-success'])
+        assertQueryResultPartial(apiResult, [
+          {
+            'api-success': [{ value: 'true' }]
           }
         ])
       })

--- a/test/functional/parsing/functional.test.ts
+++ b/test/functional/parsing/functional.test.ts
@@ -18,8 +18,8 @@ describe(__filename, () => {
         const result = scraper.query(['post'])
         assertQueryResultPartial(result, [
           {
-            post: [{ value: 'the' }, { value: 'quick' }, { value: 'brown' }, { value: 'fox' }]
-          }
+            post: [{ value: 'the' }, { value: 'quick' }, { value: 'brown' }, { value: 'fox' }],
+          },
         ])
       })
     })
@@ -32,8 +32,8 @@ describe(__filename, () => {
         const result = scraper.query(['post'])
         assertQueryResultPartial(result, [
           {
-            post: [{ value: 'the' }, { value: 'quick' }, { value: 'brown' }, { value: 'fox' }]
-          }
+            post: [{ value: 'the' }, { value: 'quick' }, { value: 'brown' }, { value: 'fox' }],
+          },
         ])
       })
     })
@@ -55,9 +55,9 @@ describe(__filename, () => {
               { value: 'over' },
               { value: 'the' },
               { value: 'lazy' },
-              { value: 'dog' }
-            ]
-          }
+              { value: 'dog' },
+            ],
+          },
         ])
       })
     })
@@ -83,16 +83,16 @@ describe(__filename, () => {
               { value: 'alsa-utils.tcz' },
               { value: 'attr.tcz' },
               { value: 'autoconf2.13.tcz' },
-              { value: 'autoconf.tcz' }
-            ]
-          }
+              { value: 'autoconf.tcz' },
+            ],
+          },
         ])
 
         const apiResult = scraper.query(['api-success'])
         assertQueryResultPartial(apiResult, [
           {
-            'api-success': [{ value: 'true' }]
-          }
+            'api-success': [{ value: 'true' }],
+          },
         ])
       })
     })

--- a/test/functional/parsing/functional.test.ts
+++ b/test/functional/parsing/functional.test.ts
@@ -18,8 +18,8 @@ describe(__filename, () => {
         const result = scraper.query(['post'])
         assertQueryResultPartial(result, [
           {
-            post: [{ value: 'the' }, { value: 'quick' }, { value: 'brown' }, { value: 'fox' }],
-          },
+            post: [{ value: 'the' }, { value: 'quick' }, { value: 'brown' }, { value: 'fox' }]
+          }
         ])
       })
     })
@@ -32,8 +32,8 @@ describe(__filename, () => {
         const result = scraper.query(['post'])
         assertQueryResultPartial(result, [
           {
-            post: [{ value: 'the' }, { value: 'quick' }, { value: 'brown' }, { value: 'fox' }],
-          },
+            post: [{ value: 'the' }, { value: 'quick' }, { value: 'brown' }, { value: 'fox' }]
+          }
         ])
       })
     })
@@ -55,9 +55,36 @@ describe(__filename, () => {
               { value: 'over' },
               { value: 'the' },
               { value: 'lazy' },
-              { value: 'dog' },
-            ],
-          },
+              { value: 'dog' }
+            ]
+          }
+        ])
+      })
+    })
+
+    describe('with delimiter parser', () => {
+      it('should be able to be fed from another parser', async () => {
+        const scraper = new ScraperProgram(
+          instructions.parseMultilineTextAsSingleLines,
+          testEnv.outputFolder
+        )
+        await scraper.start().toPromise()
+
+        const result = scraper.query(['lines'])
+        assertQueryResultPartial(result, [
+          {
+            lines: [
+              { value: 'acl.tcz' },
+              { value: 'advcomp.tcz' },
+              { value: 'alsa-plugins-dev.tcz' },
+              { value: 'alsa-plugins.tcz' },
+              { value: 'alsa.tcz' },
+              { value: 'alsa-utils.tcz' },
+              { value: 'attr.tcz' },
+              { value: 'autoconf2.13.tcz' },
+              { value: 'autoconf.tcz' }
+            ]
+          }
         ])
       })
     })

--- a/test/functional/parsing/instructions.ts
+++ b/test/functional/parsing/instructions.ts
@@ -28,4 +28,12 @@ const jsonInsideScript = `
 )
 `
 
-export { simple, parseJsonTwice, jsonInsideScript }
+const parseMultilineTextAsSingleLines = `
+(
+  FETCH '${host}/multiline-text-body.html'
+  PARSE 'pre' FORMAT='html'
+  PARSE '\\n' FORMAT='delimiter' TRIM=true LABEL='lines'
+)
+`
+
+export { simple, parseJsonTwice, jsonInsideScript, parseMultilineTextAsSingleLines }

--- a/test/functional/parsing/instructions.ts
+++ b/test/functional/parsing/instructions.ts
@@ -29,10 +29,14 @@ const jsonInsideScript = `
 `
 
 const parseMultilineTextAsSingleLines = `
+INPUT 'packageName'
 (
   FETCH '${host}/multiline-text-body.html'
   PARSE 'pre' FORMAT='html'
   PARSE '\\n' FORMAT='delimiter' TRIM=true LABEL='lines'
+).filter('"{{ value }}"' == '"{{ packageName }}"').map(
+  FETCH '${host}/success.json'
+  PARSE 'success' FORMAT='json'  LABEL='api-success'
 )
 `
 


### PR DESCRIPTION
- add the `filter` operator which functions as an opposite to `until`. It will allow values through that match a condition. It will not halt previous operations like `until` does.
- add `FORMAT='delimiter'` to the `PARSE` command.