### PR TITLE
Fixes tests and package.json to work on windows 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         os:
         - ubuntu-latest
         - macOS-latest
-        # - windows-latest # nock scope has an error w/ windows
+        - windows-latest # nock scope has an error w/ windows
       fail-fast: false
     steps:
 

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "3.5.0",
   "description": "generalized scraping using a single config object for any site that can be scraped without a headless browser",
   "scripts": {
-    "format": "prettier --write --ignore-path=.gitignore '**/!(*.api).{json,ts,js}'",
-    "format:check": "prettier --check --ignore-path=.gitignore '**/!(*.api).{json,ts,js}'",
+    "format": "prettier --write --ignore-path=.gitignore \"**/!(*.api).{json,ts,js}\"",
+    "format:check": "prettier --check --ignore-path=.gitignore \"**/!(*.api).{json,ts,js}\"",
     "typecheck": "tsc --noEmit",
     "typecheck:watch": "tsc --noEmit --watch",
-    "lint": "eslint --ignore-path .gitignore '**/*.ts'",
+    "lint": "eslint --ignore-path .gitignore \"**/*.ts\"",
     "clean": "shx rm -rf build test/.run-output node_modules/.build-artifacts node_modules/.cache/tsbuild-info.json",
     "compile": "webpack --mode=production",
     "compile:declarations": "ttsc --declaration --emitDeclarationOnly --declarationMap --outDir node_modules/.build-artifacts/declarations",
@@ -16,11 +16,11 @@
     "build:types": "run-s clean compile:declarations compile:bundle:declarations",
     "build": "run-s clean compile compile:declarations compile:bundle:declarations copy-assets",
     "test": "run-s clean typecheck test:unit test:functional lint format:check",
-    "test:watch": "mochapack '{test,src}/**/*.test.ts' --watch --clear-terminal",
-    "test:unit": "mochapack 'src/**/*.unit.test.ts'",
-    "test:functional": "mochapack 'test/functional/**/*functional.test.ts'",
+    "test:watch": "mochapack \"{test,src}/**/*.test.ts\" --watch --clear-terminal",
+    "test:unit": "mochapack \"src/**/*.unit.test.ts\"",
+    "test:functional": "mochapack \"test/functional/**/*functional.test.ts\"",
     "test:packaged": "./test/packaged/setup.sh",
-    "test:coverage": "nyc mochapack --webpack-env=coverage '{test,src}/**/*.test.ts'"
+    "test:coverage": "nyc mochapack --webpack-env=coverage \"{test,src}/**/*.test.ts\""
   },
   "repository": {
     "type": "git",

--- a/src/runtime/tools/store-tool/index.ts
+++ b/src/runtime/tools/store-tool/index.ts
@@ -32,7 +32,9 @@ class Store extends RuntimeBase {
   }
 
   public onStart(prevState: RuntimeState, initializeTables = true) {
-    this.database = new Sqlite3(Store.getSqliteFile(this.settings.folder))
+    if (this.database === undefined) {
+      this.database = new Sqlite3(Store.getSqliteFile(this.settings.folder))
+    }
     this.database.pragma('journal_mode = WAL')
 
     if (initializeTables) {

--- a/test/functional/fetch-control/functional.test.ts
+++ b/test/functional/fetch-control/functional.test.ts
@@ -2,7 +2,6 @@ import nock from 'nock'
 import { expect } from 'chai'
 import { FunctionalTestSetup, assertQueryResultPartial } from '@test/functional/setup'
 
-import { ScraperProgram } from '@scrape-pages'
 import * as instructions from './instructions'
 
 const testEnv = new FunctionalTestSetup(__dirname)
@@ -16,7 +15,7 @@ describe(__filename, () => {
       testEnv.siteMock.persist()
 
       const options = { FETCH: { defaults: { CACHE: true } } }
-      const scraper = new ScraperProgram(instructions.simple, testEnv.outputFolder, options)
+      const scraper = testEnv.addScraper(instructions.simple, testEnv.outputFolder, options)
 
       await scraper.start().toPromise()
       expect(testEnv.siteMock.requestStats.allRoutesUsed()).to.equal(true)
@@ -45,7 +44,7 @@ describe(__filename, () => {
       assertQueryResultPartial(result2, expectedResult)
 
       // we can also specify individual fetch commads to be cached
-      const scraperCachePost = new ScraperProgram(instructions.cachePost, testEnv.outputFolder)
+      const scraperCachePost = testEnv.addScraper(instructions.cachePost, testEnv.outputFolder)
       await scraperCachePost.start().toPromise()
       expect(testEnv.siteMock.requestStats.allRoutesUsed()).to.equal(false)
       expect(testEnv.siteMock.requestStats.totalRoutesUsed()).to.equal(1)
@@ -53,7 +52,7 @@ describe(__filename, () => {
       assertQueryResultPartial(result3, expectedResult)
 
       // running without cache should make normal requests
-      const scraperNoCache = new ScraperProgram(instructions.simple, testEnv.outputFolder)
+      const scraperNoCache = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
       await scraperNoCache.start().toPromise()
       expect(testEnv.siteMock.requestStats.allRoutesUsed()).to.equal(true)
       const result4 = scraperNoCache.query(['postTitle'])
@@ -69,7 +68,7 @@ describe(__filename, () => {
       (
         FETCH 'https://non-existent.com/a/b/c' LABEL='errored'
       )`
-      const scraper = new ScraperProgram(instructions, testEnv.outputFolder)
+      const scraper = testEnv.addScraper(instructions, testEnv.outputFolder)
       try {
         await scraper.start().toPromise()
         throw new Error(`scraper should have emitted 'error' not 'done'.`)
@@ -92,7 +91,7 @@ describe(__filename, () => {
       ).catch(
         REPLACE '' LABEL='caught'
       )`
-      const scraper = new ScraperProgram(instructions, testEnv.outputFolder)
+      const scraper = testEnv.addScraper(instructions, testEnv.outputFolder)
       const result = scraper.query(['errored'])
       expect(result).to.deep.equal([{ errored: [], caught: [{ value: '' }] }])
     })
@@ -106,7 +105,7 @@ describe(__filename, () => {
         FETCH 'https://fast-request' LABEL='beforeStop'
         FETCH 'https://slow-request' LABEL='afterStop'
       )`
-      const scraper = new ScraperProgram(instructions, testEnv.outputFolder)
+      const scraper = testEnv.addScraper(instructions, testEnv.outputFolder)
 
       nock('https://fast-request').get('/').reply(200)
       nock('https://slow-request')

--- a/test/functional/lifecycle-management/functional.test.ts
+++ b/test/functional/lifecycle-management/functional.test.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai'
 import { FunctionalTestSetup, assertQueryResultPartial } from '@test/functional/setup'
 
-import { ScraperProgram } from '@scrape-pages'
 import * as instructions from './instructions'
 
 const testEnv = new FunctionalTestSetup(__dirname)
@@ -11,7 +10,7 @@ describe(__filename, () => {
   afterEach(testEnv.afterEach)
 
   it('can run an empty scraper', async () => {
-    const scraper = new ScraperProgram('()', testEnv.outputFolder)
+    const scraper = testEnv.addScraper('()', testEnv.outputFolder)
     scraper.start()
     await scraper.toPromise()
   })
@@ -19,7 +18,7 @@ describe(__filename, () => {
   it('can run a scraper twice', async () => {
     testEnv.siteMock.persist()
 
-    const scraper = new ScraperProgram(instructions.simple, testEnv.outputFolder)
+    const scraper = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
     await scraper.start().toPromise()
 
     const result1 = scraper.query(['postTitle'])
@@ -43,7 +42,7 @@ describe(__filename, () => {
   it('can start a scraper after it has been stopped', async () => {
     testEnv.siteMock.persist()
 
-    const scraper = new ScraperProgram(instructions.simple, testEnv.outputFolder)
+    const scraper = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
     scraper.start()
     scraper.stop()
     await scraper.toPromise()
@@ -68,7 +67,7 @@ describe(__filename, () => {
   })
 
   it('should restrict inapproriate times to call stop() and start()', async () => {
-    const scraper = new ScraperProgram(instructions.simple, testEnv.outputFolder)
+    const scraper = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
     // cannot stop a scaper before it has started
     expect(scraper.stop).to.throw()
 
@@ -87,7 +86,7 @@ describe(__filename, () => {
   })
 
   it('should stop values coming to a command after stopCommand is called', async () => {
-    const scraper = new ScraperProgram(instructions.merging, testEnv.outputFolder)
+    const scraper = testEnv.addScraper(instructions.merging, testEnv.outputFolder)
     scraper.on('FETCH:queued', ({ LABEL }) => {
       if (LABEL === 'index') scraper.stopCommand('postTitle')
     })
@@ -112,8 +111,8 @@ describe(__filename, () => {
   it('can handle two scrapers pointed at the same folder _if_ they are not running simultaneously', async () => {
     testEnv.siteMock.persist()
 
-    const scraper1 = new ScraperProgram(instructions.simple, testEnv.outputFolder)
-    const scraper2 = new ScraperProgram(instructions.simple, testEnv.outputFolder)
+    const scraper1 = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
+    const scraper2 = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
 
     scraper1.start()
 

--- a/test/functional/looping/functional.test.ts
+++ b/test/functional/looping/functional.test.ts
@@ -12,7 +12,7 @@ describe(__filename, () => {
       let scraper: ScraperProgram
 
       before(async function () {
-        scraper = new ScraperProgram(instructions.simple, testEnv.outputFolder)
+        scraper = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
         await testEnv.beforeEach.bind(this)()
         await scraper.start().toPromise()
       })
@@ -46,7 +46,7 @@ describe(__filename, () => {
       let scraper: ScraperProgram
 
       before(async function () {
-        scraper = new ScraperProgram(instructions.merging, testEnv.outputFolder)
+        scraper = testEnv.addScraper(instructions.merging, testEnv.outputFolder)
         await testEnv.beforeEach.bind(this)()
         await scraper.start().toPromise()
       })
@@ -103,7 +103,7 @@ describe(__filename, () => {
       let scraper: ScraperProgram
 
       before(async function () {
-        scraper = new ScraperProgram(instructions.reuseLabels, testEnv.outputFolder)
+        scraper = testEnv.addScraper(instructions.reuseLabels, testEnv.outputFolder)
         await testEnv.beforeEach.bind(this)()
         await scraper.start().toPromise()
       })
@@ -160,7 +160,7 @@ describe(__filename, () => {
       let scraper: ScraperProgram
 
       before(async function () {
-        scraper = new ScraperProgram(instructions.withEmptyValue, testEnv.outputFolder)
+        scraper = testEnv.addScraper(instructions.withEmptyValue, testEnv.outputFolder)
         await testEnv.beforeEach.bind(this)()
         await scraper.start().toPromise()
       })

--- a/test/functional/nock-host-folder.ts
+++ b/test/functional/nock-host-folder.ts
@@ -57,7 +57,10 @@ class HttpFolderMock {
     const files = await fs.findFiles(this.mockEndpointsFolder)
 
     this.interceptors = files.map((file) => {
-      const relativePath = path.relative(this.mockEndpointsFolder, file)
+      const relativePath = path
+        .relative(this.mockEndpointsFolder, file)
+        .split(path.sep)
+        .join(path.posix.sep)
       const fullPath = path.resolve(this.mockEndpointsFolder, file)
       const route = `/${relativePath}`
       this.requestStats.addRoute(route)

--- a/test/functional/parsing/functional.test.ts
+++ b/test/functional/parsing/functional.test.ts
@@ -1,6 +1,5 @@
 import { FunctionalTestSetup, assertQueryResultPartial } from '@test/functional/setup'
 
-import { ScraperProgram } from '@scrape-pages'
 import * as instructions from './instructions'
 
 const testEnv = new FunctionalTestSetup(__dirname)
@@ -12,7 +11,7 @@ describe(__filename, () => {
   describe('json', () => {
     describe('with simple instructions', () => {
       it(`should handle FORMAT='json'`, async () => {
-        const scraper = new ScraperProgram(instructions.simple, testEnv.outputFolder)
+        const scraper = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
         await scraper.start().toPromise()
 
         const result = scraper.query(['post'])
@@ -26,7 +25,7 @@ describe(__filename, () => {
 
     describe('with twice parsed json', () => {
       it('should handle json being passed from a parse', async () => {
-        const scraper = new ScraperProgram(instructions.parseJsonTwice, testEnv.outputFolder)
+        const scraper = testEnv.addScraper(instructions.parseJsonTwice, testEnv.outputFolder)
         await scraper.start().toPromise()
 
         const result = scraper.query(['post'])
@@ -40,7 +39,7 @@ describe(__filename, () => {
 
     describe('with json inside another document', () => {
       it('should parse any valid json from a string', async () => {
-        const scraper = new ScraperProgram(instructions.jsonInsideScript, testEnv.outputFolder)
+        const scraper = testEnv.addScraper(instructions.jsonInsideScript, testEnv.outputFolder)
         await scraper.start().toPromise()
 
         const result = scraper.query(['words'])

--- a/test/functional/recursion/functional.test.ts
+++ b/test/functional/recursion/functional.test.ts
@@ -8,9 +8,10 @@ describe(__filename, () => {
   describe('query ordering', () => {
     describe('with simple instructions', () => {
       let scraper: ScraperProgram
+
       before(async function () {
         await testEnv.beforeEach.bind(this)()
-        scraper = new ScraperProgram(instructions.simple, testEnv.outputFolder)
+        scraper = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
         await scraper.start().toPromise()
       })
       after(testEnv.afterEach)
@@ -67,7 +68,7 @@ describe(__filename, () => {
       let scraper: ScraperProgram
 
       before(async function () {
-        scraper = new ScraperProgram(instructions.merging, testEnv.outputFolder)
+        scraper = testEnv.addScraper(instructions.merging, testEnv.outputFolder)
         await testEnv.beforeEach.bind(this)()
         await scraper.start().toPromise()
       })


### PR DESCRIPTION
* Updates `package.json` to contain wildcards that will work on both Windows and Linux
* `onStart` in `src/runtime/tools/index.ts` no longer discards open SQLite handles when it is called
* Adds list of `ScraperProgram` objects to functional test setup that are closed at the end of each test to fix open file descriptor encountered on Windows
* Updates `nock-host-folder.ts` to properly set up mock HTTP server when locating files on Windows computer