### PR TITLE
Fixes tests and package.json to work on windows 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         os:
         - ubuntu-latest
         - macOS-latest
-        # - windows-latest # nock scope has an error w/ windows
+        - windows-latest # nock scope has an error w/ windows
       fail-fast: false
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,10 @@ jobs:
 
     - run: pnpm install --frozen-lockfile --strict-peer-dependencies
     - run: pnpm run build
+    - run: pnpm run format
+    - run: pnpm run format:check
+    - run: git status
+    - run: git diff webpack.config.js
     - run: pnpm run test
 
     - run: pnpm run test:coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,10 +62,6 @@ jobs:
 
     - run: pnpm install --frozen-lockfile --strict-peer-dependencies
     - run: pnpm run build
-    - run: pnpm run format
-    - run: pnpm run format:check
-    - run: git status
-    - run: git diff webpack.config.js
     - run: pnpm run test
 
     - run: pnpm run test:coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         os:
         - ubuntu-latest
         - macOS-latest
-        - windows-latest # nock scope has an error w/ windows
+        - windows-latest
       fail-fast: false
     steps:
 

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,5 @@
 {
+  "endOfLine": "auto",
   "semi": false,
   "singleQuote": true,
   "printWidth": 100

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "3.5.0",
   "description": "generalized scraping using a single config object for any site that can be scraped without a headless browser",
   "scripts": {
-    "format": "prettier --write --ignore-path=.gitignore '**/!(*.api).{json,ts,js}'",
-    "format:check": "prettier --check --ignore-path=.gitignore '**/!(*.api).{json,ts,js}'",
+    "format": "prettier --write --ignore-path=.gitignore \"**/!(*.api).{json,ts,js}\"",
+    "format:check": "prettier --check --ignore-path=.gitignore \"**/!(*.api).{json,ts,js}\"",
     "typecheck": "tsc --noEmit",
     "typecheck:watch": "tsc --noEmit --watch",
-    "lint": "eslint --ignore-path .gitignore '**/*.ts'",
+    "lint": "eslint --ignore-path .gitignore \"**/*.ts\"",
     "clean": "shx rm -rf build test/.run-output node_modules/.build-artifacts node_modules/.cache/tsbuild-info.json",
     "compile": "webpack --mode=production",
     "compile:declarations": "ttsc --declaration --emitDeclarationOnly --declarationMap --outDir node_modules/.build-artifacts/declarations",
@@ -16,11 +16,11 @@
     "build:types": "run-s clean compile:declarations compile:bundle:declarations",
     "build": "run-s clean compile compile:declarations compile:bundle:declarations copy-assets",
     "test": "run-s clean typecheck test:unit test:functional lint format:check",
-    "test:watch": "mochapack '{test,src}/**/*.test.ts' --watch --clear-terminal",
-    "test:unit": "mochapack 'src/**/*.unit.test.ts'",
-    "test:functional": "mochapack 'test/functional/**/*functional.test.ts'",
+    "test:watch": "mochapack \"{test,src}/**/*.test.ts\" --watch --clear-terminal",
+    "test:unit": "mochapack \"src/**/*.unit.test.ts\"",
+    "test:functional": "mochapack \"test/functional/**/*functional.test.ts\"",
     "test:packaged": "./test/packaged/setup.sh",
-    "test:coverage": "nyc mochapack --webpack-env=coverage '{test,src}/**/*.test.ts'"
+    "test:coverage": "nyc mochapack --webpack-env=coverage \"{test,src}/**/*.test.ts\""
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
     "pre-push": "^0.1.1",
-    "prettier": "^2.0.5",
+    "prettier": "2.0.5",
     "readline-sync": "^1.4.10",
     "shx": "^0.3.2",
     "ts-loader": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
     "pre-push": "^0.1.1",
-    "prettier": "2.0.5",
+    "prettier": "^2.0.5",
     "readline-sync": "^1.4.10",
     "shx": "^0.3.2",
     "ts-loader": "^8.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1776,6 +1776,7 @@ packages:
     resolution:
       integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   /discontinuous-range/1.0.0:
+    dev: false
     resolution:
       integrity: sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=
   /doctrine/1.5.0:
@@ -3821,6 +3822,7 @@ packages:
     resolution:
       integrity: sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==
   /moo/0.5.1:
+    dev: false
     resolution:
       integrity: sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==
   /move-concurrently/1.0.1:
@@ -3904,6 +3906,7 @@ packages:
       railroad-diagrams: 1.0.0
       randexp: 0.4.6
       semver: 5.7.1
+    dev: false
     hasBin: true
     resolution:
       integrity: sha512-qoh1ZXXl0Kpn40tFhmgvffUAlbpRMcjLUagNVnT1JmliUIsB4tFabmCNhD97+tkf9FZ/SLhhYzNow0V3GitzDg==
@@ -4603,12 +4606,14 @@ packages:
     resolution:
       integrity: sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
   /railroad-diagrams/1.0.0:
+    dev: false
     resolution:
       integrity: sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=
   /randexp/0.4.6:
     dependencies:
       discontinuous-range: 1.0.0
       ret: 0.1.15
+    dev: false
     engines:
       node: '>=0.12'
     resolution:
@@ -5719,6 +5724,7 @@ packages:
     resolution:
       integrity: sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
   /typescript/3.9.7:
+    dev: true
     engines:
       node: '>=4.2.0'
     hasBin: true
@@ -6151,7 +6157,7 @@ specifiers:
   npm-run-all: ^4.1.5
   nyc: ^15.1.0
   pre-push: ^0.1.1
-  prettier: ^2.0.5
+  prettier: 2.0.5
   readline-sync: ^1.4.10
   rxjs: ^6.6.0
   seamless-immutable: ^7.1.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6157,7 +6157,7 @@ specifiers:
   npm-run-all: ^4.1.5
   nyc: ^15.1.0
   pre-push: ^0.1.1
-  prettier: 2.0.5
+  prettier: ^2.0.5
   readline-sync: ^1.4.10
   rxjs: ^6.6.0
   seamless-immutable: ^7.1.4

--- a/src/runtime/tools/store-tool/index.ts
+++ b/src/runtime/tools/store-tool/index.ts
@@ -32,7 +32,9 @@ class Store extends RuntimeBase {
   }
 
   public onStart(prevState: RuntimeState, initializeTables = true) {
-    this.database = new Sqlite3(Store.getSqliteFile(this.settings.folder))
+    if (this.database === undefined) {
+      this.database = new Sqlite3(Store.getSqliteFile(this.settings.folder))
+    }
     this.database.pragma('journal_mode = WAL')
 
     if (initializeTables) {

--- a/test/functional/fetch-control/functional.test.ts
+++ b/test/functional/fetch-control/functional.test.ts
@@ -15,7 +15,7 @@ describe(__filename, () => {
       testEnv.siteMock.persist()
 
       const options = { FETCH: { defaults: { CACHE: true } } }
-      const scraper = testEnv.addScraper(instructions.simple, testEnv.outputFolder, options)
+      const scraper = testEnv.attachScraper(instructions.simple, testEnv.outputFolder, options)
 
       await scraper.start().toPromise()
       expect(testEnv.siteMock.requestStats.allRoutesUsed()).to.equal(true)
@@ -44,7 +44,7 @@ describe(__filename, () => {
       assertQueryResultPartial(result2, expectedResult)
 
       // we can also specify individual fetch commads to be cached
-      const scraperCachePost = testEnv.addScraper(instructions.cachePost, testEnv.outputFolder)
+      const scraperCachePost = testEnv.attachScraper(instructions.cachePost, testEnv.outputFolder)
       await scraperCachePost.start().toPromise()
       expect(testEnv.siteMock.requestStats.allRoutesUsed()).to.equal(false)
       expect(testEnv.siteMock.requestStats.totalRoutesUsed()).to.equal(1)
@@ -52,7 +52,7 @@ describe(__filename, () => {
       assertQueryResultPartial(result3, expectedResult)
 
       // running without cache should make normal requests
-      const scraperNoCache = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
+      const scraperNoCache = testEnv.attachScraper(instructions.simple, testEnv.outputFolder)
       await scraperNoCache.start().toPromise()
       expect(testEnv.siteMock.requestStats.allRoutesUsed()).to.equal(true)
       const result4 = scraperNoCache.query(['postTitle'])
@@ -68,7 +68,7 @@ describe(__filename, () => {
       (
         FETCH 'https://non-existent.com/a/b/c' LABEL='errored'
       )`
-      const scraper = testEnv.addScraper(instructions, testEnv.outputFolder)
+      const scraper = testEnv.attachScraper(instructions, testEnv.outputFolder)
       try {
         await scraper.start().toPromise()
         throw new Error(`scraper should have emitted 'error' not 'done'.`)
@@ -91,7 +91,7 @@ describe(__filename, () => {
       ).catch(
         REPLACE '' LABEL='caught'
       )`
-      const scraper = testEnv.addScraper(instructions, testEnv.outputFolder)
+      const scraper = testEnv.attachScraper(instructions, testEnv.outputFolder)
       const result = scraper.query(['errored'])
       expect(result).to.deep.equal([{ errored: [], caught: [{ value: '' }] }])
     })
@@ -105,7 +105,7 @@ describe(__filename, () => {
         FETCH 'https://fast-request' LABEL='beforeStop'
         FETCH 'https://slow-request' LABEL='afterStop'
       )`
-      const scraper = testEnv.addScraper(instructions, testEnv.outputFolder)
+      const scraper = testEnv.attachScraper(instructions, testEnv.outputFolder)
 
       nock('https://fast-request').get('/').reply(200)
       nock('https://slow-request')

--- a/test/functional/fetch-control/functional.test.ts
+++ b/test/functional/fetch-control/functional.test.ts
@@ -2,7 +2,6 @@ import nock from 'nock'
 import { expect } from 'chai'
 import { FunctionalTestSetup, assertQueryResultPartial } from '@test/functional/setup'
 
-import { ScraperProgram } from '@scrape-pages'
 import * as instructions from './instructions'
 
 const testEnv = new FunctionalTestSetup(__dirname)
@@ -16,7 +15,7 @@ describe(__filename, () => {
       testEnv.siteMock.persist()
 
       const options = { FETCH: { defaults: { CACHE: true } } }
-      const scraper = new ScraperProgram(instructions.simple, testEnv.outputFolder, options)
+      const scraper = testEnv.addScraper(instructions.simple, testEnv.outputFolder, options)
 
       await scraper.start().toPromise()
       expect(testEnv.siteMock.requestStats.allRoutesUsed()).to.equal(true)
@@ -45,7 +44,7 @@ describe(__filename, () => {
       assertQueryResultPartial(result2, expectedResult)
 
       // we can also specify individual fetch commads to be cached
-      const scraperCachePost = new ScraperProgram(instructions.cachePost, testEnv.outputFolder)
+      const scraperCachePost = testEnv.addScraper(instructions.cachePost, testEnv.outputFolder)
       await scraperCachePost.start().toPromise()
       expect(testEnv.siteMock.requestStats.allRoutesUsed()).to.equal(false)
       expect(testEnv.siteMock.requestStats.totalRoutesUsed()).to.equal(1)
@@ -53,7 +52,7 @@ describe(__filename, () => {
       assertQueryResultPartial(result3, expectedResult)
 
       // running without cache should make normal requests
-      const scraperNoCache = new ScraperProgram(instructions.simple, testEnv.outputFolder)
+      const scraperNoCache = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
       await scraperNoCache.start().toPromise()
       expect(testEnv.siteMock.requestStats.allRoutesUsed()).to.equal(true)
       const result4 = scraperNoCache.query(['postTitle'])
@@ -69,7 +68,7 @@ describe(__filename, () => {
       (
         FETCH 'https://non-existent.com/a/b/c' LABEL='errored'
       )`
-      const scraper = new ScraperProgram(instructions, testEnv.outputFolder)
+      const scraper = testEnv.addScraper(instructions, testEnv.outputFolder)
       try {
         await scraper.start().toPromise()
         throw new Error(`scraper should have emitted 'error' not 'done'.`)
@@ -92,7 +91,7 @@ describe(__filename, () => {
       ).catch(
         REPLACE '' LABEL='caught'
       )`
-      const scraper = new ScraperProgram(instructions, testEnv.outputFolder)
+      const scraper = testEnv.addScraper(instructions, testEnv.outputFolder)
       const result = scraper.query(['errored'])
       expect(result).to.deep.equal([{ errored: [], caught: [{ value: '' }] }])
     })
@@ -106,7 +105,7 @@ describe(__filename, () => {
         FETCH 'https://fast-request' LABEL='beforeStop'
         FETCH 'https://slow-request' LABEL='afterStop'
       )`
-      const scraper = new ScraperProgram(instructions, testEnv.outputFolder)
+      const scraper = testEnv.addScraper(instructions, testEnv.outputFolder)
 
       nock('https://fast-request').get('/').reply(200)
       nock('https://slow-request')

--- a/test/functional/lifecycle-management/functional.test.ts
+++ b/test/functional/lifecycle-management/functional.test.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai'
 import { FunctionalTestSetup, assertQueryResultPartial } from '@test/functional/setup'
 
-import { ScraperProgram } from '@scrape-pages'
 import * as instructions from './instructions'
 
 const testEnv = new FunctionalTestSetup(__dirname)
@@ -11,7 +10,7 @@ describe(__filename, () => {
   afterEach(testEnv.afterEach)
 
   it('can run an empty scraper', async () => {
-    const scraper = new ScraperProgram('()', testEnv.outputFolder)
+    const scraper = testEnv.addScraper('()', testEnv.outputFolder)
     scraper.start()
     await scraper.toPromise()
   })
@@ -19,7 +18,7 @@ describe(__filename, () => {
   it('can run a scraper twice', async () => {
     testEnv.siteMock.persist()
 
-    const scraper = new ScraperProgram(instructions.simple, testEnv.outputFolder)
+    const scraper = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
     await scraper.start().toPromise()
 
     const result1 = scraper.query(['postTitle'])
@@ -43,7 +42,7 @@ describe(__filename, () => {
   it('can start a scraper after it has been stopped', async () => {
     testEnv.siteMock.persist()
 
-    const scraper = new ScraperProgram(instructions.simple, testEnv.outputFolder)
+    const scraper = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
     scraper.start()
     scraper.stop()
     await scraper.toPromise()
@@ -68,7 +67,7 @@ describe(__filename, () => {
   })
 
   it('should restrict inapproriate times to call stop() and start()', async () => {
-    const scraper = new ScraperProgram(instructions.simple, testEnv.outputFolder)
+    const scraper = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
     // cannot stop a scaper before it has started
     expect(scraper.stop).to.throw()
 
@@ -87,7 +86,7 @@ describe(__filename, () => {
   })
 
   it('should stop values coming to a command after stopCommand is called', async () => {
-    const scraper = new ScraperProgram(instructions.merging, testEnv.outputFolder)
+    const scraper = testEnv.addScraper(instructions.merging, testEnv.outputFolder)
     scraper.on('FETCH:queued', ({ LABEL }) => {
       if (LABEL === 'index') scraper.stopCommand('postTitle')
     })
@@ -112,8 +111,8 @@ describe(__filename, () => {
   it('can handle two scrapers pointed at the same folder _if_ they are not running simultaneously', async () => {
     testEnv.siteMock.persist()
 
-    const scraper1 = new ScraperProgram(instructions.simple, testEnv.outputFolder)
-    const scraper2 = new ScraperProgram(instructions.simple, testEnv.outputFolder)
+    const scraper1 = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
+    const scraper2 = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
 
     scraper1.start()
 

--- a/test/functional/lifecycle-management/functional.test.ts
+++ b/test/functional/lifecycle-management/functional.test.ts
@@ -10,7 +10,7 @@ describe(__filename, () => {
   afterEach(testEnv.afterEach)
 
   it('can run an empty scraper', async () => {
-    const scraper = testEnv.addScraper('()', testEnv.outputFolder)
+    const scraper = testEnv.attachScraper('()', testEnv.outputFolder)
     scraper.start()
     await scraper.toPromise()
   })
@@ -18,7 +18,7 @@ describe(__filename, () => {
   it('can run a scraper twice', async () => {
     testEnv.siteMock.persist()
 
-    const scraper = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
+    const scraper = testEnv.attachScraper(instructions.simple, testEnv.outputFolder)
     await scraper.start().toPromise()
 
     const result1 = scraper.query(['postTitle'])
@@ -42,7 +42,7 @@ describe(__filename, () => {
   it('can start a scraper after it has been stopped', async () => {
     testEnv.siteMock.persist()
 
-    const scraper = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
+    const scraper = testEnv.attachScraper(instructions.simple, testEnv.outputFolder)
     scraper.start()
     scraper.stop()
     await scraper.toPromise()
@@ -67,7 +67,7 @@ describe(__filename, () => {
   })
 
   it('should restrict inapproriate times to call stop() and start()', async () => {
-    const scraper = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
+    const scraper = testEnv.attachScraper(instructions.simple, testEnv.outputFolder)
     // cannot stop a scaper before it has started
     expect(scraper.stop).to.throw()
 
@@ -86,7 +86,7 @@ describe(__filename, () => {
   })
 
   it('should stop values coming to a command after stopCommand is called', async () => {
-    const scraper = testEnv.addScraper(instructions.merging, testEnv.outputFolder)
+    const scraper = testEnv.attachScraper(instructions.merging, testEnv.outputFolder)
     scraper.on('FETCH:queued', ({ LABEL }) => {
       if (LABEL === 'index') scraper.stopCommand('postTitle')
     })
@@ -111,8 +111,8 @@ describe(__filename, () => {
   it('can handle two scrapers pointed at the same folder _if_ they are not running simultaneously', async () => {
     testEnv.siteMock.persist()
 
-    const scraper1 = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
-    const scraper2 = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
+    const scraper1 = testEnv.attachScraper(instructions.simple, testEnv.outputFolder)
+    const scraper2 = testEnv.attachScraper(instructions.simple, testEnv.outputFolder)
 
     scraper1.start()
 

--- a/test/functional/looping/functional.test.ts
+++ b/test/functional/looping/functional.test.ts
@@ -12,7 +12,7 @@ describe(__filename, () => {
       let scraper: ScraperProgram
 
       before(async function () {
-        scraper = new ScraperProgram(instructions.simple, testEnv.outputFolder)
+        scraper = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
         await testEnv.beforeEach.bind(this)()
         await scraper.start().toPromise()
       })
@@ -46,7 +46,7 @@ describe(__filename, () => {
       let scraper: ScraperProgram
 
       before(async function () {
-        scraper = new ScraperProgram(instructions.merging, testEnv.outputFolder)
+        scraper = testEnv.addScraper(instructions.merging, testEnv.outputFolder)
         await testEnv.beforeEach.bind(this)()
         await scraper.start().toPromise()
       })
@@ -103,7 +103,7 @@ describe(__filename, () => {
       let scraper: ScraperProgram
 
       before(async function () {
-        scraper = new ScraperProgram(instructions.reuseLabels, testEnv.outputFolder)
+        scraper = testEnv.addScraper(instructions.reuseLabels, testEnv.outputFolder)
         await testEnv.beforeEach.bind(this)()
         await scraper.start().toPromise()
       })
@@ -160,7 +160,7 @@ describe(__filename, () => {
       let scraper: ScraperProgram
 
       before(async function () {
-        scraper = new ScraperProgram(instructions.withEmptyValue, testEnv.outputFolder)
+        scraper = testEnv.addScraper(instructions.withEmptyValue, testEnv.outputFolder)
         await testEnv.beforeEach.bind(this)()
         await scraper.start().toPromise()
       })

--- a/test/functional/looping/functional.test.ts
+++ b/test/functional/looping/functional.test.ts
@@ -12,7 +12,7 @@ describe(__filename, () => {
       let scraper: ScraperProgram
 
       before(async function () {
-        scraper = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
+        scraper = testEnv.attachScraper(instructions.simple, testEnv.outputFolder)
         await testEnv.beforeEach.bind(this)()
         await scraper.start().toPromise()
       })
@@ -46,7 +46,7 @@ describe(__filename, () => {
       let scraper: ScraperProgram
 
       before(async function () {
-        scraper = testEnv.addScraper(instructions.merging, testEnv.outputFolder)
+        scraper = testEnv.attachScraper(instructions.merging, testEnv.outputFolder)
         await testEnv.beforeEach.bind(this)()
         await scraper.start().toPromise()
       })
@@ -103,7 +103,7 @@ describe(__filename, () => {
       let scraper: ScraperProgram
 
       before(async function () {
-        scraper = testEnv.addScraper(instructions.reuseLabels, testEnv.outputFolder)
+        scraper = testEnv.attachScraper(instructions.reuseLabels, testEnv.outputFolder)
         await testEnv.beforeEach.bind(this)()
         await scraper.start().toPromise()
       })
@@ -160,7 +160,7 @@ describe(__filename, () => {
       let scraper: ScraperProgram
 
       before(async function () {
-        scraper = testEnv.addScraper(instructions.withEmptyValue, testEnv.outputFolder)
+        scraper = testEnv.attachScraper(instructions.withEmptyValue, testEnv.outputFolder)
         await testEnv.beforeEach.bind(this)()
         await scraper.start().toPromise()
       })

--- a/test/functional/nock-host-folder.ts
+++ b/test/functional/nock-host-folder.ts
@@ -57,7 +57,10 @@ class HttpFolderMock {
     const files = await fs.findFiles(this.mockEndpointsFolder)
 
     this.interceptors = files.map((file) => {
-      const relativePath = path.relative(this.mockEndpointsFolder, file)
+      const relativePath = path
+        .relative(this.mockEndpointsFolder, file)
+        .split(path.sep)
+        .join(path.posix.sep)
       const fullPath = path.resolve(this.mockEndpointsFolder, file)
       const route = `/${relativePath}`
       this.requestStats.addRoute(route)

--- a/test/functional/parsing/functional.test.ts
+++ b/test/functional/parsing/functional.test.ts
@@ -1,6 +1,5 @@
 import { FunctionalTestSetup, assertQueryResultPartial } from '@test/functional/setup'
 
-import { ScraperProgram } from '@scrape-pages'
 import * as instructions from './instructions'
 
 const testEnv = new FunctionalTestSetup(__dirname)
@@ -12,7 +11,7 @@ describe(__filename, () => {
   describe('json', () => {
     describe('with simple instructions', () => {
       it(`should handle FORMAT='json'`, async () => {
-        const scraper = new ScraperProgram(instructions.simple, testEnv.outputFolder)
+        const scraper = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
         await scraper.start().toPromise()
 
         const result = scraper.query(['post'])
@@ -26,7 +25,7 @@ describe(__filename, () => {
 
     describe('with twice parsed json', () => {
       it('should handle json being passed from a parse', async () => {
-        const scraper = new ScraperProgram(instructions.parseJsonTwice, testEnv.outputFolder)
+        const scraper = testEnv.addScraper(instructions.parseJsonTwice, testEnv.outputFolder)
         await scraper.start().toPromise()
 
         const result = scraper.query(['post'])
@@ -40,7 +39,7 @@ describe(__filename, () => {
 
     describe('with json inside another document', () => {
       it('should parse any valid json from a string', async () => {
-        const scraper = new ScraperProgram(instructions.jsonInsideScript, testEnv.outputFolder)
+        const scraper = testEnv.addScraper(instructions.jsonInsideScript, testEnv.outputFolder)
         await scraper.start().toPromise()
 
         const result = scraper.query(['words'])

--- a/test/functional/parsing/functional.test.ts
+++ b/test/functional/parsing/functional.test.ts
@@ -11,7 +11,7 @@ describe(__filename, () => {
   describe('json', () => {
     describe('with simple instructions', () => {
       it(`should handle FORMAT='json'`, async () => {
-        const scraper = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
+        const scraper = testEnv.attachScraper(instructions.simple, testEnv.outputFolder)
         await scraper.start().toPromise()
 
         const result = scraper.query(['post'])
@@ -25,7 +25,7 @@ describe(__filename, () => {
 
     describe('with twice parsed json', () => {
       it('should handle json being passed from a parse', async () => {
-        const scraper = testEnv.addScraper(instructions.parseJsonTwice, testEnv.outputFolder)
+        const scraper = testEnv.attachScraper(instructions.parseJsonTwice, testEnv.outputFolder)
         await scraper.start().toPromise()
 
         const result = scraper.query(['post'])
@@ -39,7 +39,7 @@ describe(__filename, () => {
 
     describe('with json inside another document', () => {
       it('should parse any valid json from a string', async () => {
-        const scraper = testEnv.addScraper(instructions.jsonInsideScript, testEnv.outputFolder)
+        const scraper = testEnv.attachScraper(instructions.jsonInsideScript, testEnv.outputFolder)
         await scraper.start().toPromise()
 
         const result = scraper.query(['words'])

--- a/test/functional/recursion/functional.test.ts
+++ b/test/functional/recursion/functional.test.ts
@@ -8,9 +8,10 @@ describe(__filename, () => {
   describe('query ordering', () => {
     describe('with simple instructions', () => {
       let scraper: ScraperProgram
+
       before(async function () {
         await testEnv.beforeEach.bind(this)()
-        scraper = new ScraperProgram(instructions.simple, testEnv.outputFolder)
+        scraper = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
         await scraper.start().toPromise()
       })
       after(testEnv.afterEach)
@@ -67,7 +68,7 @@ describe(__filename, () => {
       let scraper: ScraperProgram
 
       before(async function () {
-        scraper = new ScraperProgram(instructions.merging, testEnv.outputFolder)
+        scraper = testEnv.addScraper(instructions.merging, testEnv.outputFolder)
         await testEnv.beforeEach.bind(this)()
         await scraper.start().toPromise()
       })

--- a/test/functional/recursion/functional.test.ts
+++ b/test/functional/recursion/functional.test.ts
@@ -11,7 +11,7 @@ describe(__filename, () => {
 
       before(async function () {
         await testEnv.beforeEach.bind(this)()
-        scraper = testEnv.addScraper(instructions.simple, testEnv.outputFolder)
+        scraper = testEnv.attachScraper(instructions.simple, testEnv.outputFolder)
         await scraper.start().toPromise()
       })
       after(testEnv.afterEach)
@@ -68,7 +68,7 @@ describe(__filename, () => {
       let scraper: ScraperProgram
 
       before(async function () {
-        scraper = testEnv.addScraper(instructions.merging, testEnv.outputFolder)
+        scraper = testEnv.attachScraper(instructions.merging, testEnv.outputFolder)
         await testEnv.beforeEach.bind(this)()
         await scraper.start().toPromise()
       })

--- a/test/functional/setup.ts
+++ b/test/functional/setup.ts
@@ -46,9 +46,7 @@ class FunctionalTestSetup {
 
   public afterEach = () => {
     for (const scraper of this.scrapers) {
-      if ((scraper as any).runtime.tools.store.database.open) {
-        ;(scraper as any).runtime.tools.store.database.close()
-      }
+      ;(scraper as any).runtime.tools.store.database.close()
     }
     this.scrapers = []
     this.siteMock.done()
@@ -65,9 +63,10 @@ class FunctionalTestSetup {
     return queryExecutionDebugger
   }
 
-  public addScraper(instructionsArg: string, folder: string, options?: Options) {
-    const newSize = this.scrapers.push(new ScraperProgram(instructionsArg, folder, options))
-    return this.scrapers[newSize - 1]
+  public attachScraper(instructionsArg: string, folder: string, options?: Options) {
+    const scraper = new ScraperProgram(instructionsArg, folder, options)
+    this.scrapers.push(scraper)
+    return scraper
   }
 }
 


### PR DESCRIPTION
* Updates `package.json` to contain wildcards that will work on both Windows and Linux
* `onStart` in `src/runtime/tools/index.ts` no longer discards open SQLite handles when it is called
* Adds list of `ScraperProgram` objects to functional test setup that are closed at the end of each test to fix open file descriptor encountered on Windows
* Updates `nock-host-folder.ts` to properly set up mock HTTP server when locating files on Windows computer